### PR TITLE
Install molecule-plugins[docker] explicitly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ ansible-compat==4.1.10
 ansible-core==2.15.6
 ansible-lint==6.22.0
 molecule==6.0.2
-molecule-plugins==23.4.1
+molecule-plugins[docker]==23.5.0
 pytest-testinfra==10.0.0
 urllib3<2


### PR DESCRIPTION
Without specifying this plugin CI using this image can crash, so let's fix this plugin. We also pin the version to use the latest one.