### PR TITLE
Set specific version for requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ distlib==0.3.8
 molecule==6.0.2
 molecule-plugins[docker]==23.5.0
 pytest-testinfra==10.0.0
+requests==2.31.0
 urllib3<2
 yq==3.4.3


### PR DESCRIPTION
We define a specific version for requests lib because it breaks the docker-py behind module and docker integration.

More information about that problem:
https://github.com/docker/docker-py/issues/3256