### PR TITLE
Add optional dependency for image with old ansible-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,24 @@
 FROM python:3.12-alpine AS builder
+ARG EXTRA=""
+
 
 RUN apk add --no-cache python3 python3-dev py3-pip gcc \
 	git curl build-base autoconf automake py3-cryptography \
 	linux-headers musl-dev libffi-dev openssl-dev
 
 COPY . /usr/local/src/ansible_collection_helper
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /build/wheels /usr/local/src/ansible_collection_helper
+RUN pip wheel --no-cache-dir --no-deps --wheel-dir /build/wheels \
+    "/usr/local/src/ansible_collection_helper${EXTRA:+[$EXTRA]}"
 
 FROM docker:28.1.1-dind
+ARG EXTRA
 RUN apk add --no-cache python3 py3-pip jq py3-cryptography rsync \
     openssh-client git libpq
+
 COPY --from=builder /build/wheels /wheels
 COPY --from=ghcr.io/astral-sh/uv:0.10.5 /uv /uvx /bin/
+
 RUN uv venv /opt/venv --python 3.12 && \
-    uv pip install --no-cache --python /opt/venv /wheels/*
+    uv pip install --no-cache --python /opt/venv \
+    --find-links wheels \
+    "ansible_collection_helper${EXTRA:+[$EXTRA]}"

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build -f "${DOCKERFILE_PATH}" -t "${IMAGE_NAME}" .
+docker build --build-arg EXTRA=legacy -f "${DOCKERFILE_PATH}" \
+    -t "${IMAGE_NAME}-legacy" .

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker push "${DOCKER_REPO}:${IMAGE_NAME}-legacy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dynamic = ["version", "dependencies"]
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[project.optional-dependencies]
+legacy = [
+    "ansible-core < 2.17"
+]
+
 [project.urls]
 Source = "https://github.com/dalibo/docker-dind-molecule/"
 Tracker = "https://github.com/dalibo/docker-dind-molecule/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible-lint>=26.1.1
-ansible>=13,<14
+ansible<14
 codespell==2.4.1
 distlib==0.4.0
 molecule-plugins[docker]==25.8.12


### PR DESCRIPTION
So with that new optional dependency, we can build image with latest supported ansible-core or with the last ansible-core compatible with RHEL8.

To build image with older version, we can use the EXTRA var: docker build --build-arg EXTRA=legacy -t ... .