### PR TITLE
Fix image name when pushing it to DockerHub

### DIFF
--- a/hooks/post_push
+++ b/hooks/post_push
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker push "${DOCKER_REPO}:${IMAGE_NAME}-legacy"
+docker push "${IMAGE_NAME}-legacy"


### PR DESCRIPTION
Docker repo is already included on the Docker image, so no need to specify it again.

Related to: f029fc303d58982fd3c2345e7ca8b1063f209f8a